### PR TITLE
Fix CursorLine capitalization in vim template

### DIFF
--- a/app/resources/templates/vim.txt
+++ b/app/resources/templates/vim.txt
@@ -34,7 +34,7 @@ let s:warning2="{{warning2}}"
 
 exe 'hi Normal guifg='s:fg' guibg='s:bg 
 exe 'hi Cursor guifg='s:bg' guibg='s:fg 
-exe 'hi Cursorline  guibg='s:bg2 
+exe 'hi CursorLine  guibg='s:bg2 
 exe 'hi CursorColumn  guibg='s:bg2 
 exe 'hi ColorColumn  guibg='s:bg2 
 exe 'hi LineNr guifg='s:fg2' guibg='s:bg2 


### PR DESCRIPTION
`Cursorline` still works, but I thought I'd fix it for the sake of consistency.