### PR TITLE
Add WildMenu Syntax Highlighting

### DIFF
--- a/app.core/resources/public/templates/vim.txt
+++ b/app.core/resources/public/templates/vim.txt
@@ -32,60 +32,61 @@ let s:var="{{variable}}"
 let s:warning="{{warning}}"
 let s:warning2="{{warning2}}"
 
-exe 'hi Normal guifg='s:fg' guibg='s:bg 
-exe 'hi Cursor guifg='s:bg' guibg='s:fg 
-exe 'hi CursorLine  guibg='s:bg2 
-exe 'hi CursorColumn  guibg='s:bg2 
-exe 'hi ColorColumn  guibg='s:bg2 
-exe 'hi LineNr guifg='s:fg2' guibg='s:bg2 
-exe 'hi VertSplit guifg='s:fg3' guibg='s:bg3 
+exe 'hi Normal guifg='s:fg' guibg='s:bg
+exe 'hi Cursor guifg='s:bg' guibg='s:fg
+exe 'hi CursorLine  guibg='s:bg2
+exe 'hi CursorColumn  guibg='s:bg2
+exe 'hi ColorColumn  guibg='s:bg2
+exe 'hi LineNr guifg='s:fg2' guibg='s:bg2
+exe 'hi VertSplit guifg='s:fg3' guibg='s:bg3
 exe 'hi MatchParen guifg='s:warning2'  gui=underline'
 exe 'hi StatusLine guifg='s:fg2' guibg='s:bg3' gui=bold'
 exe 'hi Pmenu guifg='s:fg' guibg='s:bg2
-exe 'hi PmenuSel  guibg='s:bg3 
-exe 'hi IncSearch guifg='s:bg' guibg='s:keyword 
+exe 'hi PmenuSel  guibg='s:bg3
+exe 'hi IncSearch guifg='s:bg' guibg='s:keyword
 exe 'hi Search   gui=underline'
-exe 'hi Directory guifg='s:const  
-exe 'hi Folded guifg='s:fg4' guibg='s:bg 
+exe 'hi Directory guifg='s:const
+exe 'hi Folded guifg='s:fg4' guibg='s:bg
+exe 'hi WildMenu guifg='s:str' guibg='s:bg
 
-exe 'hi Boolean guifg='s:const  
-exe 'hi Character guifg='s:const  
-exe 'hi Comment guifg='s:comment  
-exe 'hi Conditional guifg='s:keyword  
-exe 'hi Constant guifg='s:const  
-exe 'hi Define guifg='s:keyword  
+exe 'hi Boolean guifg='s:const
+exe 'hi Character guifg='s:const
+exe 'hi Comment guifg='s:comment
+exe 'hi Conditional guifg='s:keyword
+exe 'hi Constant guifg='s:const
+exe 'hi Define guifg='s:keyword
 {{#hasdarkbg}}
 exe 'hi DiffAdd guifg=#fafafa guibg=#123d0f gui=bold'
-exe 'hi DiffDelete guibg='s:bg2  
+exe 'hi DiffDelete guibg='s:bg2
 exe 'hi DiffChange  guibg=#151b3c guifg=#fafafa'
 exe 'hi DiffText guifg=#ffffff guibg=#ff0000 gui=bold'
 {{/hasdarkbg}}
 {{^hasdarkbg}}
 exe 'hi DiffAdd guifg=#000000 guibg=#bef6dc gui=bold'
-exe 'hi DiffDelete guifg='s:bg2  
+exe 'hi DiffDelete guifg='s:bg2
 exe 'hi DiffChange  guibg=#5b76ef guifg=#ffffff'
 exe 'hi DiffText guifg=#ffffff guibg=#ff0000 gui=bold'
 {{/hasdarkbg}}
 exe 'hi ErrorMsg guifg='s:warning' guibg='s:bg2' gui=bold'
-exe 'hi WarningMsg guifg='s:fg' guibg='s:warning2 
-exe 'hi Float guifg='s:const  
-exe 'hi Function guifg='s:func  
+exe 'hi WarningMsg guifg='s:fg' guibg='s:warning2
+exe 'hi Float guifg='s:const
+exe 'hi Function guifg='s:func
 exe 'hi Identifier guifg='s:type'  gui=italic'
 exe 'hi Keyword guifg='s:keyword'  gui=bold'
 exe 'hi Label guifg='s:var
-exe 'hi NonText guifg='s:bg4' guibg='s:bg2 
-exe 'hi Number guifg='s:const  
-exe 'hi Operater guifg='s:keyword  
-exe 'hi PreProc guifg='s:keyword  
-exe 'hi Special guifg='s:fg  
-exe 'hi SpecialKey guifg='s:fg2' guibg='s:bg2 
-exe 'hi Statement guifg='s:keyword  
+exe 'hi NonText guifg='s:bg4' guibg='s:bg2
+exe 'hi Number guifg='s:const
+exe 'hi Operater guifg='s:keyword
+exe 'hi PreProc guifg='s:keyword
+exe 'hi Special guifg='s:fg
+exe 'hi SpecialKey guifg='s:fg2' guibg='s:bg2
+exe 'hi Statement guifg='s:keyword
 exe 'hi StorageClass guifg='s:type'  gui=italic'
-exe 'hi String guifg='s:str  
-exe 'hi Tag guifg='s:keyword  
+exe 'hi String guifg='s:str
+exe 'hi Tag guifg='s:keyword
 exe 'hi Title guifg='s:fg'  gui=bold'
 exe 'hi Todo guifg='s:fg2'  gui=inverse,bold'
-exe 'hi Type guifg='s:type 
+exe 'hi Type guifg='s:type
 exe 'hi Underlined   gui=underline'
 
 " Ruby Highlighting


### PR DESCRIPTION
WildMenu is the menu which popups when you tab complete commands in
vim command mode.
I made it so that the foreground of the selected item for tab completion is the `string` color
and the background is the same as `mainbg` which contrasts with the StatusLine color.

Sorry about the seemingly big pr, my editor removes trailing spaces automatically when saving...