### PR TITLE
Add syntax for relativenumber and Todos

### DIFF
--- a/app.core/resources/public/templates/vim.txt
+++ b/app.core/resources/public/templates/vim.txt
@@ -35,6 +35,7 @@ let s:warning2="{{warning2}}"
 exe 'hi Normal guifg='s:fg' guibg='s:bg
 exe 'hi Cursor guifg='s:bg' guibg='s:fg
 exe 'hi CursorLine  guibg='s:bg2
+exe 'hi CursorLineNr guifg='s:str' guibg='s:bg
 exe 'hi CursorColumn  guibg='s:bg2
 exe 'hi ColorColumn  guibg='s:bg2
 exe 'hi LineNr guifg='s:fg2' guibg='s:bg2
@@ -54,6 +55,7 @@ exe 'hi Character guifg='s:const
 exe 'hi Comment guifg='s:comment
 exe 'hi Conditional guifg='s:keyword
 exe 'hi Constant guifg='s:const
+exe 'hi Todo guibg='s:bg
 exe 'hi Define guifg='s:keyword
 {{#hasdarkbg}}
 exe 'hi DiffAdd guifg=#fafafa guibg=#123d0f gui=bold'


### PR DESCRIPTION
The following elements used yellow (`#FFFF00`) instead of
using a color belonging to the colorscheme:

- Current cursor line while using relativenumber (`CursorLineNr`)
- Cotetags foreground (`Todos`)

Codetag examples would be `TODO`, `FIXME`, `BUG`, etc...
Foreground and background are inverted since it appears highlighted.
Therefore I change the background color to `s:bg` to make it look good.