### PR TITLE
More golang syntax AND neovim terminal mode fix

### DIFF
--- a/app.core/resources/public/templates/vim.txt
+++ b/app.core/resources/public/templates/vim.txt
@@ -89,6 +89,24 @@ exe 'hi Todo guifg='s:fg2'  gui=inverse,bold'
 exe 'hi Type guifg='s:type
 exe 'hi Underlined   gui=underline'
 
+" Neovim Terminal Mode
+let g:terminal_color_0 = s:bg
+let g:terminal_color_1 = s:warning
+let g:terminal_color_2 = s:keyword
+let g:terminal_color_3 = s:bg4
+let g:terminal_color_4 = s:func
+let g:terminal_color_5 = s:builtin
+let g:terminal_color_6 = s:fg3
+let g:terminal_color_7 = s:str
+let g:terminal_color_8 = s:bg2
+let g:terminal_color_9 = s:warning2
+let g:terminal_color_10 = s:fg2
+let g:terminal_color_11 = s:var
+let g:terminal_color_12 = s:type
+let g:terminal_color_13 = s:const
+let g:terminal_color_14 = s:fg4
+let g:terminal_color_15 = s:comment
+
 " Ruby Highlighting
 exe 'hi rubyAttribute guifg='s:builtin
 exe 'hi rubyLocalVariableOrMethod guifg='s:var
@@ -105,6 +123,22 @@ exe 'hi pythonBuiltinFunc guifg='s:builtin
 
 " Go Highlighting
 exe 'hi goBuiltins guifg='s:builtin
+let g:go_highlight_array_whitespace_error = 1
+let g:go_highlight_build_constraints      = 1
+let g:go_highlight_chan_whitespace_error  = 1
+let g:go_highlight_extra_types            = 1
+let g:go_highlight_fields                 = 1
+let g:go_highlight_format_strings         = 1
+let g:go_highlight_function_calls         = 1
+let g:go_highlight_function_parameters    = 1
+let g:go_highlight_functions              = 1
+let g:go_highlight_generate_tags          = 1
+let g:go_highlight_operators              = 1
+let g:go_highlight_space_tab_error        = 1
+let g:go_highlight_string_spellcheck      = 1
+let g:go_highlight_types                  = 1
+let g:go_highlight_variable_assignments   = 1
+let g:go_highlight_variable_declarations  = 1
 
 " Javascript Highlighting
 exe 'hi jsBuiltins guifg='s:builtin


### PR DESCRIPTION
Like I mentionned in [my issue](https://github.com/mswift42/themecreator/issues/12#issue-626795230), the neovim terminal mode should work fine with this.

I also enabled more colorscheme parameters for the Go programming language
(it make the whole thing less plain). It was suggested to me by someone who uses my personal 
vim colorscheme and I think it would be great to have it enabled in the colorscheme generator.

Anyway, feel free to remove the golang part out if you feel like it doesn't belong. ;)