### PR TITLE
Remove duplicate definition of line-number faces and make tab-line look prettier

### DIFF
--- a/app.core/resources/public/templates/emacs.txt
+++ b/app.core/resources/public/templates/emacs.txt
@@ -1,4 +1,4 @@
-;;; {{themename}}-theme.el --- Theme 
+;;; {{themename}}-theme.el --- Theme
 
 ;; Copyright (C) {{year}} , {{themeauthor}}
 
@@ -136,7 +136,7 @@
         `(js3-function-param-face ((,class (:foreground ,fg2))))
         `(js3-jsdoc-tag-face ((,class (:foreground ,keyword))))
         `(js3-instance-member-face ((,class (:foreground ,const))))
-	`(warning ((,class (:foreground ,warning)))) 
+	`(warning ((,class (:foreground ,warning))))
 	`(ac-completion-face ((,class (:underline t :foreground ,keyword))))
 	`(info-quoted-name ((,class (:foreground ,builtin))))
 	`(info-string ((,class (:foreground ,str))))
@@ -256,8 +256,6 @@
   (when (>= emacs-major-version 27)
     (custom-theme-set-faces
      '{{themename}}
-     `(line-number ((t (:background ,bg2 :foreground ,fg4))))
-     `(line-number-current-line ((t (:background ,bg2 :foreground ,fg1))))
      `(tab-line ((,class (:inherit fringe :box (:line-width 4 :color ,bg2)))))
      `(tab-line-tab ((,class (:inherit tab-line))))
      `(tab-line-tab-inactive ((,class (:inherit tab-line :foreground ,comment))))

--- a/app.core/resources/public/templates/emacs.txt
+++ b/app.core/resources/public/templates/emacs.txt
@@ -256,12 +256,11 @@
   (when (>= emacs-major-version 27)
     (custom-theme-set-faces
      '{{themename}}
-     `(tab-line ((,class (:inherit fringe :box (:line-width 4 :color ,bg2)))))
-     `(tab-line-tab ((,class (:inherit tab-line))))
-     `(tab-line-tab-inactive ((,class (:inherit tab-line :foreground ,comment))))
-     `(tab-line-tab-current  ((,class (:background ,bg4 :foreground ,fg1 :box (:line-width 4 :color ,bg4)))))
-     `(tab-line-highlight    ((,class (:background ,bg1 :foreground ,fg2 :box (:line-width 4 :color ,bg1)))))))
-
+     `(tab-line              ((,class (:background ,bg2 :foreground ,fg4))))
+     `(tab-line-tab          ((,class (:inherit tab-line))))
+     `(tab-line-tab-inactive ((,class (:background ,bg2 :foreground ,fg4))))
+     `(tab-line-tab-current  ((,class (:background ,bg1 :foreground ,fg1))))
+     `(tab-line-highlight    ((,class (:background ,bg1 :foreground ,fg2))))))
    )
 
 ;;;###autoload


### PR DESCRIPTION
HI

I've noticed that the line-numbers are defined twice and that's not necessary. Additionally I have tweaked the tab-line a bit:

1. Active tab looks like buffer, while others look like the fringe.
2. Move the tab-line resizing outside the theme. There might be people who are happy with the default size settings for the tab-line (not my case, but I do that after loading the theme).

