### PR TITLE
Inital implementation of theme template for TextAdept

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 ![Screenshot](https://github.com/mswift42/themecreator/raw/master/screenshots/tc1chromehamburg.png)
 
-Create Color Themes for IntelliJ Editors, Atom, Emacs, Textmate, Vim and Gnome Terminal.
+Create Color Themes for IntelliJ Editors, Atom, Emacs, TextAdept, Textmate, Vim and Gnome Terminal.
 
 
 Installation Instructions:
@@ -24,13 +24,16 @@ To create an UI Theme plugin for jetbrains editors >= 191, go to [iui](https://g
 with your newly generated theme.
 
 ### Textmate:
-Download the textmate theme, then follow your editors instructions. For Visual Studio Code you can use the [yeoman code](https://code.visualstudio.com/docs/tools/yocode) generator. 
+Download the textmate theme, then follow your editors instructions. For Visual Studio Code you can use the [yeoman code](https://code.visualstudio.com/docs/tools/yocode) generator.
 
 ### Atom:
 [Generate](https://atom.io/docs/latest/hacking-atom-creating-a-theme) a new color theme from within atom. Then Download the atom theme you made with ThemeCreator, and download [base.less](https://github.com/mswift42/themecreator/raw/master/base.less) and [syntax-variables.less](https://github.com/mswift42/themecreator/raw/master/syntax-variables.less). Now copy the 3 files, `colors.less`, `base.less` and `syntax-variables.less` into the `styles/` folder of the Atom generated theme.
 
 ### Emacs:
 Download the emacs file. Add a fitting package description to the first line. You can try your new theme by visiting your new theme with `C-x C-f <filename.el>`. You can install your new theme with: `M-x package-install-file <filename.el>`.
+
+### TextAdept:
+Download the TextAdept file. Copy it into your ~/.textadept/themes directory, edit your preferences to use it and restart TextAdept.
 
 ### Vim:
 Download the vim theme and copy it to your `colors` folder. For Vim that's usually `~/.vim/colors`, for Neovim it's `~/.config/nvim/colors` .
@@ -104,6 +107,3 @@ ThemeCreator's maintenance has been made a lot easier with the support of
 <a href="https://www.jetbrains.com"> <img src="https://github.com/mswift42/themecreator/raw/master/jetbrains.png" width="200" height = "200" alt="JetBrains" /> </a>
 
 Thank you JetBrains.
-
-
-

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -1,0 +1,138 @@
+;;; {{themename}}.lua
+
+;; Copyright (C) {{year}} , {{themeauthor}}
+
+;; Author: {{themeauthor}}
+;; Version: 0.1
+;; Package-Requires: ((emacs "24"))
+;; Created with ThemeCreator, https://github.com/mswift42/themecreator.
+
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+;; This file is not part of TextAdept
+
+;;; Commentary:
+
+;;; Code:
+
+local view, colors, styles = view, lexer.colors, lexer.styles
+
+
+colors.fg1      = {{mainfg}}
+colors.fg2      = {{fg2}}
+colors.fg3      = {{fg3}}
+colors.fg4      = {{fg4}}
+colors.bg1      = {{mainbg}}
+colors.bg2      = {{bg2}}
+colors.bg3      = {{bg3}}
+colors.bg4      = {{bg4}}
+colors.builtin  = {{builtin}}
+colors.keyword  = {{keyword}}
+colors.const    = {{constant}}
+colors.comment  = {{comment}}
+colors.func     = {{functionname}}
+colors.str      = {{string}}
+colors.type     = {{type}}
+colors.var      = {{variable}}
+colors.warning  = {{warning}}
+colors.warning2 = {{warning2}}
+
+-- Default font.
+if not font then
+  font = 'Dejavu Sans Mono'
+end
+if not size then
+   size = 12
+end
+
+-- Find/replace dialog
+ui.find.entry_font = font .. ' ' .. (size - 1)
+
+-- Predefined styles.
+styles.default = {
+  font = font, size = size, fore = colors.fg1, back = colors.bg1
+}
+
+styles.line_number = {fore = colors.fg2, back = colors.bg2}
+--styles.control_char =
+styles.indent_guide = {fore = colors.fg3}
+styles.call_tip = {fore = colors.fg3, back = colors.bg2}
+styles.fold_display_text = {fore = colors.fg2}
+
+-- Token styles.
+styles.class = {fore = colors.func}
+styles.comment = {fore = colors.comment}
+styles.constant = {fore = colors.const}
+styles.embedded = {fore = colors.builtin, back = colors.bg1}
+styles.error = {fore = colors.warning2, italics = true}
+styles['function'] = {fore = colors.func}
+styles.identifier = {}
+styles.keyword = {fore = colors.keyword}
+styles.label = {fore = colors.const}
+styles.number = {fore = colors.fg1}
+styles.operator = {fore = colors.fg1}
+styles.preprocessor = {fore = colors.builtin}
+styles.regex = {fore = colors.str}
+styles.string = {fore = colors.str}
+styles.type = {fore = colors.type}
+styles.variable = {fore = colors.var}
+styles.whitespace = {}
+
+-- Multiple Selection and Virtual Space
+--view.additional_sel_alpha =
+--view.additional_sel_fore =
+--view.additional_sel_back =
+--view.additional_caret_fore =
+
+-- Caret and Selection Styles.
+view:set_sel_fore(true, colors.base06)
+view:set_sel_back(true, colors.base02)
+--view.sel_alpha =
+view.caret_fore = colors.base05
+view.caret_line_back = colors.base01
+--view.caret_line_back_alpha =
+
+-- Fold Margin.
+view:set_fold_margin_color(true, colors.fg1)
+view:set_fold_margin_hi_color(true, colors.fg1)
+
+-- Markers.
+view.marker_back[textadept.bookmarks.MARK_BOOKMARK] = colors.fg4
+view.marker_back[textadept.run.MARK_WARNING] = colors.warning
+view.marker_back[textadept.run.MARK_ERROR] = colors.warning2
+for i = view.MARKNUM_FOLDEREND, view.MARKNUM_FOLDEROPEN do -- fold margin
+  view.marker_fore[i] = colors.fg1
+  view.marker_back[i] = colors.bg2
+  view.marker_back_selected[i] = colors.bg3
+end
+
+-- Indicators.
+view.indic_fore[ui.find.INDIC_FIND] = colors.const
+view.indic_alpha[ui.find.INDIC_FIND] = 255
+view.indic_fore[textadept.editing.INDIC_BRACEMATCH] = colors.fg3
+view.indic_fore[textadept.editing.INDIC_HIGHLIGHT] = colors.fg2
+view.indic_alpha[textadept.editing.INDIC_HIGHLIGHT] = 64
+view.indic_fore[textadept.snippets.INDIC_PLACEHOLDER] = colors.fg3
+
+-- Call tips.
+view.call_tip_fore_hlt = colors.fg2
+
+-- Long Lines.
+view.edge_color = colors.fg3
+
+-- Add red, green, and yellow for diff lexer.
+colors.red = colors.warning
+colors.green = colors.str
+colors.yellow = colors.keyword

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -4,7 +4,6 @@
 
 -- Author: {{themeauthor}}
 -- Version: 0.1
--- Package-Requires: ((emacs "24"))
 -- Created with ThemeCreator, https://github.com/mswift42/themecreator.
 
 -- This program is free software: you can redistribute it and/or modify

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -20,25 +20,26 @@
 -- along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 -- This file is not part of TextAdept
+local view, colors, styles = view, lexer.colors, lexer.styles
 
-colors.fg1      = {{mainfg}}
-colors.fg2      = {{fg2}}
-colors.fg3      = {{fg3}}
-colors.fg4      = {{fg4}}
-colors.bg1      = {{mainbg}}
-colors.bg2      = {{bg2}}
-colors.bg3      = {{bg3}}
-colors.bg4      = {{bg4}}
-colors.builtin  = {{builtin}}
-colors.keyword  = {{keyword}}
-colors.const    = {{constant}}
-colors.comment  = {{comment}}
-colors.func     = {{functionname}}
-colors.str      = {{string}}
-colors.type     = {{type}}
-colors.var      = {{variable}}
-colors.warning  = {{warning}}
-colors.warning2 = {{warning2}}
+colors.fg1      = "{{mainfg}}"
+colors.fg2      = "{{fg2}}"
+colors.fg3      = "{{fg3}}"
+colors.fg4      = "{{fg4}}"
+colors.bg1      = "{{mainbg}}"
+colors.bg2      = "{{bg2}}"
+colors.bg3      = "{{bg3}}"
+colors.bg4      = "{{bg4}}"
+colors.builtin  = "{{builtin}}"
+colors.keyword  = "{{keyword}}"
+colors.const    = "{{constant}}"
+colors.comment  = "{{comment}}"
+colors.func     = "{{functionname}}"
+colors.str      = "{{string}}"
+colors.type     = "{{type}}"
+colors.var      = "{{variable}}"
+colors.warning  = "{{warning}}"
+colors.warning2 = "{{warning2}}"
 
 -- Default font.
 if not font then

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -67,7 +67,7 @@ styles.constant = {fore = colors.const}
 styles.embedded = {fore = colors.builtin, back = colors.bg2}
 styles.error = {fore = colors.warning, italics = true}
 styles['function'] = {fore = colors.func}
-styles.identifier = {}
+styles.identifier = {fore=colors.var}
 styles.keyword = {fore = colors.keyword}
 styles.label = {fore = colors.warning}
 styles.number = {fore = colors.const}

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -1,34 +1,26 @@
-;;; {{themename}}.lua
+--- {{themename}}.lua
 
-;; Copyright (C) {{year}} , {{themeauthor}}
+-- Copyright (C) {{year}} , {{themeauthor}}
 
-;; Author: {{themeauthor}}
-;; Version: 0.1
-;; Package-Requires: ((emacs "24"))
-;; Created with ThemeCreator, https://github.com/mswift42/themecreator.
+-- Author: {{themeauthor}}
+-- Version: 0.1
+-- Package-Requires: ((emacs "24"))
+-- Created with ThemeCreator, https://github.com/mswift42/themecreator.
 
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
 
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+-- GNU General Public License for more details.
 
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-;; GNU General Public License for more details.
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-;; You should have received a copy of the GNU General Public License
-;; along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-;; This file is not part of TextAdept
-
-;;; Commentary:
-
-;;; Code:
-
-local view, colors, styles = view, lexer.colors, lexer.styles
-
+-- This file is not part of TextAdept
 
 colors.fg1      = {{mainfg}}
 colors.fg2      = {{fg2}}
@@ -51,12 +43,10 @@ colors.warning2 = {{warning2}}
 
 -- Default font.
 if not font then
-  font = 'Dejavu Sans Mono'
+  font = WIN32 and 'Courier New' or OSX and 'Monaco' or
+    'Bitstream Vera Sans Mono'
 end
-if not size then
-   size = 12
-end
-
+if not size then size = not OSX and 10 or 12 end
 -- Find/replace dialog
 ui.find.entry_font = font .. ' ' .. (size - 1)
 
@@ -64,30 +54,29 @@ ui.find.entry_font = font .. ' ' .. (size - 1)
 styles.default = {
   font = font, size = size, fore = colors.fg1, back = colors.bg1
 }
-
-styles.line_number = {fore = colors.fg2, back = colors.bg2}
+styles.line_number = {fore = colors.fg1, back = colors.bg2}
 --styles.control_char =
-styles.indent_guide = {fore = colors.fg3}
-styles.call_tip = {fore = colors.fg3, back = colors.bg2}
-styles.fold_display_text = {fore = colors.fg2}
+styles.indent_guide = {fore = colors.comment}
+styles.call_tip = {fore = colors.fg1, back = colors.bg2}
+styles.fold_display_text = {fore = colors.bg2}
 
 -- Token styles.
 styles.class = {fore = colors.func}
 styles.comment = {fore = colors.comment}
 styles.constant = {fore = colors.const}
-styles.embedded = {fore = colors.builtin, back = colors.bg1}
-styles.error = {fore = colors.warning2, italics = true}
+styles.embedded = {fore = colors.builtin, back = colors.bg2}
+styles.error = {fore = colors.warning, italics = true}
 styles['function'] = {fore = colors.func}
 styles.identifier = {}
 styles.keyword = {fore = colors.keyword}
-styles.label = {fore = colors.const}
-styles.number = {fore = colors.fg1}
-styles.operator = {fore = colors.fg1}
-styles.preprocessor = {fore = colors.builtin}
+styles.label = {fore = colors.warning}
+styles.number = {fore = colors.const}
+styles.operator = {fore = colors.fg2}
+styles.preprocessor = {fore = colors.str}
 styles.regex = {fore = colors.str}
 styles.string = {fore = colors.str}
-styles.type = {fore = colors.type}
-styles.variable = {fore = colors.var}
+styles.type = {fore = colors.func}
+styles.variable = {fore = colors.warning}
 styles.whitespace = {}
 
 -- Multiple Selection and Virtual Space
@@ -97,24 +86,27 @@ styles.whitespace = {}
 --view.additional_caret_fore =
 
 -- Caret and Selection Styles.
-view:set_sel_fore(true, colors.base06)
-view:set_sel_back(true, colors.base02)
+view:set_sel_fore(true, colors.fg3)
+view:set_sel_back(true, colors.bg3)
 --view.sel_alpha =
-view.caret_fore = colors.base05
-view.caret_line_back = colors.base01
+view.caret_fore = colors.fg2
+view.caret_line_back = colors.bg2
 --view.caret_line_back_alpha =
 
 -- Fold Margin.
-view:set_fold_margin_color(true, colors.fg1)
-view:set_fold_margin_hi_color(true, colors.fg1)
+view:set_fold_margin_color(true, colors.bg2)
+view:set_fold_margin_hi_color(true, colors.bg2)
 
 -- Markers.
-view.marker_back[textadept.bookmarks.MARK_BOOKMARK] = colors.fg4
-view.marker_back[textadept.run.MARK_WARNING] = colors.warning
-view.marker_back[textadept.run.MARK_ERROR] = colors.warning2
+--view.marker_fore[textadept.bookmarks.MARK_BOOKMARK] = colors.bg1
+view.marker_back[textadept.bookmarks.MARK_BOOKMARK] = colors.str
+--view.marker_fore[textadept.run.MARK_WARNING] = colors.bg1
+view.marker_back[textadept.run.MARK_WARNING] = colors.keyword
+--view.marker_fore[textadept.run.MARK_ERROR] = colors.bg1
+view.marker_back[textadept.run.MARK_ERROR] = colors.warning
 for i = view.MARKNUM_FOLDEREND, view.MARKNUM_FOLDEROPEN do -- fold margin
-  view.marker_fore[i] = colors.fg1
-  view.marker_back[i] = colors.bg2
+  view.marker_fore[i] = colors.bg1
+  view.marker_back[i] = colors.comment
   view.marker_back_selected[i] = colors.bg3
 end
 
@@ -122,15 +114,15 @@ end
 view.indic_fore[ui.find.INDIC_FIND] = colors.const
 view.indic_alpha[ui.find.INDIC_FIND] = 255
 view.indic_fore[textadept.editing.INDIC_BRACEMATCH] = colors.fg3
-view.indic_fore[textadept.editing.INDIC_HIGHLIGHT] = colors.fg2
+view.indic_fore[textadept.editing.INDIC_HIGHLIGHT] = colors.fg4
 view.indic_alpha[textadept.editing.INDIC_HIGHLIGHT] = 64
-view.indic_fore[textadept.snippets.INDIC_PLACEHOLDER] = colors.fg3
+view.indic_fore[textadept.snippets.INDIC_PLACEHOLDER] = colors.fg1
 
 -- Call tips.
-view.call_tip_fore_hlt = colors.fg2
+view.call_tip_fore_hlt = colors.fg3
 
 -- Long Lines.
-view.edge_color = colors.fg3
+view.edge_color = colors.bg3
 
 -- Add red, green, and yellow for diff lexer.
 colors.red = colors.warning

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -22,24 +22,24 @@
 -- This file is not part of TextAdept
 local view, colors, styles = view, lexer.colors, lexer.styles
 
-colors.fg1      = "{{mainfg}}"
-colors.fg2      = "{{fg2}}"
-colors.fg3      = "{{fg3}}"
-colors.fg4      = "{{fg4}}"
-colors.bg1      = "{{mainbg}}"
-colors.bg2      = "{{bg2}}"
-colors.bg3      = "{{bg3}}"
-colors.bg4      = "{{bg4}}"
-colors.builtin  = "{{builtin}}"
-colors.keyword  = "{{keyword}}"
-colors.const    = "{{constant}}"
-colors.comment  = "{{comment}}"
-colors.func     = "{{functionname}}"
-colors.str      = "{{string}}"
-colors.type     = "{{type}}"
-colors.var      = "{{variable}}"
-colors.warning  = "{{warning}}"
-colors.warning2 = "{{warning2}}"
+colors.fg1      = {{mainfg}}
+colors.fg2      = {{fg2}}
+colors.fg3      = {{fg3}}
+colors.fg4      = {{fg4}}
+colors.bg1      = {{mainbg}}
+colors.bg2      = {{bg2}}
+colors.bg3      = {{bg3}}
+colors.bg4      = {{bg4}}
+colors.builtin  = {{builtin}}
+colors.keyword  = {{keyword}}
+colors.const    = {{constant}}
+colors.comment  = {{comment}}
+colors.func     = {{functionname}}
+colors.str      = {{string}}
+colors.type     = {{type}}
+colors.var      = {{variable}}
+colors.warning  = {{warning}}
+colors.warning2 = {{warning2}}
 
 -- Default font.
 if not font then
@@ -62,7 +62,7 @@ styles.call_tip = {fore = colors.fg1, back = colors.bg2}
 styles.fold_display_text = {fore = colors.bg2}
 
 -- Token styles.
-styles.class = {fore = colors.func}
+styles.class = {fore = colors.func, bold = true}
 styles.comment = {fore = colors.comment}
 styles.constant = {fore = colors.const}
 styles.embedded = {fore = colors.builtin, back = colors.bg2}

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -87,8 +87,8 @@ styles.whitespace = {}
 --view.additional_caret_fore =
 
 -- Caret and Selection Styles.
-view:set_sel_fore(true, colors.fg2)
-view:set_sel_back(true, colors.bg2)
+view:set_sel_fore(true, colors.fg3)
+view:set_sel_back(true, colors.bg3)
 --view.sel_alpha =
 view.caret_fore = colors.fg2
 view.caret_line_back = colors.bg2

--- a/app.core/resources/public/templates/textadept.txt
+++ b/app.core/resources/public/templates/textadept.txt
@@ -43,10 +43,11 @@ colors.warning2 = "{{warning2}}"
 
 -- Default font.
 if not font then
-  font = WIN32 and 'Courier New' or OSX and 'Monaco' or
+  font = WIN32 and 'Consolas' or OSX and 'Monaco' or
     'Bitstream Vera Sans Mono'
 end
-if not size then size = not OSX and 10 or 12 end
+if not size then size = OSX and 12 or 11 end
+
 -- Find/replace dialog
 ui.find.entry_font = font .. ' ' .. (size - 1)
 
@@ -86,8 +87,8 @@ styles.whitespace = {}
 --view.additional_caret_fore =
 
 -- Caret and Selection Styles.
-view:set_sel_fore(true, colors.fg3)
-view:set_sel_back(true, colors.bg3)
+view:set_sel_fore(true, colors.fg2)
+view:set_sel_back(true, colors.bg2)
 --view.sel_alpha =
 view.caret_fore = colors.fg2
 view.caret_line_back = colors.bg2

--- a/app.core/src/app/app.cljs
+++ b/app.core/src/app/app.cljs
@@ -24,6 +24,7 @@
 (def tmthemetemplate (atom ""))
 (def atomtemplate (atom ""))
 (def emacstemplate (atom ""))
+(def tatemplate (atom ""))
 (def vimtemplate (atom ""))
 (def gnometerminaltemplate (atom ""))
 (def vscodetemplate (atom ""))
@@ -111,6 +112,8 @@
      (str (:themename @app-db) ".tmTheme") @tmthemetemplate]
     [template-download "emacslink" "Emacs"
      (str (:themename @app-db) "-theme.el") @emacstemplate ]
+    [template-download "talink" "TextAdept"
+     (str (:themename @app-db) ".lua") @tatemplate ]
     [template-download "vimlink" "Vim"
      (str (:themename @app-db) ".vim") @vimtemplate]
     [template-download "gnometerminallink" "Gnome Terminal"
@@ -178,6 +181,7 @@
   (GET "templates/intelli.txt" intellitemplate)
   (GET "templates/tmtheme.txt" tmthemetemplate)
   (GET "templates/emacs.txt" emacstemplate)
+  (GET "templates/textadept.txt" tatemplate)
   (GET "templates/vim.txt" vimtemplate)
   (GET "templates/gnome-terminal.txt" gnometerminaltemplate)
   (GET "templates/vscode/package.json" vscodepackagejsontemplate)


### PR DESCRIPTION
Hi

Although my main editor is Emacs, I include TextAdept in the lab environments I'm responsible for. The editor is located at: 
https://github.com/orbitalquark/textadept
if you don't now it.

I hope I didn't forget anything. I tried to test on a Ubuntu focal VM, but I need to get used to Clojure I fear...

/PA