### PR TITLE
Improvements for Docker integrataion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM clojure
+# Better mount the cloned app.core directory
 # COPY app.core /usr/src/app
+RUN useradd -ms /bin/bash devel
+USER devel
 WORKDIR /usr/src/app
 CMD ["clj", "-M:fig:build"]
 EXPOSE 9500/tcp

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ use them.
 
 `build-sh.run` will expose the container port `9500` to the host/VM where you are running
 ThemeCreator. If you are running ThemeCreator inside Dockeer inside a VM, you may also
-need to add a port translation for your virtual machine to access ThemeCreator from your host.
+need to add a port translation for your virtual machine to access ThemeCreator from you host.
 
 This has been tested on a Ubuntu 20.04 server VM running on VirtualBox and on KVM directly.
 

--- a/build-run.sh
+++ b/build-run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 docker build -t themecreator:test .
-docker run --network=host -it -v $(pwd)/app.core:/usr/src/app \
+docker run --network=host -it \
+       -u $UD:$GID -v $(pwd)/app.core:/usr/src/app \
        --name test themecreator:test

--- a/build-run.sh
+++ b/build-run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 docker build -t themecreator:test .
 docker run --network=host -it \
-       -u $UD:$GID -v $(pwd)/app.core:/usr/src/app \
+       -u $UID:$GID -v $(pwd)/app.core:/usr/src/app \
        --name test themecreator:test

--- a/kill-clean.sh
+++ b/kill-clean.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-docker container kill test
-docker rm $(docker ps -aq)
+[ -n "$(docker ps -aq -f status=running)" ] && \
+	  docker container kill test
+ZOMBIES="$(docker ps -aq -f status=exited)"
+[ -n "$ZOMBIES" ] && docker rm "$ZOMBIES"
 docker rmi themecreator:test
+find . -type d -group docker -exec rm -rf {} \;


### PR DESCRIPTION
In addition to cleaning up stupid typos in Readme.md, I have moved the Dockerfile to

1. Run `clj` as a non privileged user
2. mount the cloned app.core instead of copying it inside the container

This allows some edits to reflect on a running themecreator container on-the-fly, making development easier

In addition, I have updated the helper scripts to reflect the changes in Dockerfile