### PR TITLE
Add missing Vim built-in highlight groups

### DIFF
--- a/app.core/resources/public/templates/vim.txt
+++ b/app.core/resources/public/templates/vim.txt
@@ -38,7 +38,10 @@ exe 'hi CursorLine  guibg='s:bg2
 exe 'hi CursorLineNr guifg='s:str' guibg='s:bg
 exe 'hi CursorColumn  guibg='s:bg2
 exe 'hi ColorColumn  guibg='s:bg2
+exe 'hi FoldColumn guifg='s:comment' guibg='s:bg2
+exe 'hi SignColumn guifg='s:comment' guibg='s:bg2
 exe 'hi LineNr guifg='s:fg2' guibg='s:bg2
+exe 'hi CursorLineNr guifg='s:fg' guibg='s:bg2
 exe 'hi VertSplit guifg='s:fg3' guibg='s:bg3
 exe 'hi MatchParen guifg='s:warning2'  gui=underline'
 exe 'hi StatusLine guifg='s:fg2' guibg='s:bg3' gui=bold'


### PR DESCRIPTION
This patch will only show a difference if you have e.g. `set foldcolumn=auto signcolumn=auto` in `.vimrc`,
as the default option value is `set foldcolumn=0`.

Before the patch (got column highlights from the Vim `default` color scheme):
<img width="1392" alt="before" src="https://user-images.githubusercontent.com/10341686/209295788-fda71020-f622-404c-9d67-a878114895ca.png">

After the patch:
<img width="1392" alt="after" src="https://user-images.githubusercontent.com/10341686/209295925-7d66b3e9-02e0-4d83-bd03-33b021755f1b.png">
