### PR TITLE
Add preliminary Textadept 12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 pom.xml
 pom.xml.asc
 *jar
+*rej
+*orig
 /lib/
 /classes/
 /target/

--- a/app.core/resources/public/templates/emacs.txt
+++ b/app.core/resources/public/templates/emacs.txt
@@ -272,7 +272,12 @@
      `(tab-line-tab          ((,class (:inherit tab-line))))
      `(tab-line-tab-inactive ((,class (:background ,bg2 :foreground ,fg4))))
      `(tab-line-tab-current  ((,class (:background ,bg1 :foreground ,fg1))))
-     `(tab-line-highlight    ((,class (:background ,bg1 :foreground ,fg2)))))))
+     `(tab-line-highlight    ((,class (:background ,bg1 :foreground ,fg2))))))
+ (when (>= emacs-major-version 28)
+    (custom-theme-set-faces
+     '{{themename}}
+     `(tab-line-tab-modified ((,class (:foreground ,func :weight bold))))))
+)
 
 ;;;###autoload
 (when load-file-name

--- a/app.core/resources/public/templates/emacs.txt
+++ b/app.core/resources/public/templates/emacs.txt
@@ -33,6 +33,7 @@
       (fg2 "{{fg2}}")
       (fg3 "{{fg3}}")
       (fg4 "{{fg4}}")
+      (fg6 "{{fg6}}")
       (bg1 "{{mainbg}}")
       (bg2 "{{bg2}}")
       (bg3 "{{bg3}}")
@@ -258,12 +259,8 @@
      (custom-theme-set-faces
       '{{themename}}
       `(line-number ((t (:inherit fringe))))
-     {{#hasdarkbg}}
-      `(line-number-current-line ((t (:inherit fringe :foreground "white" :weight bold))))))
-     {{/hasdarkbg}}
-     {{^hasdarkbg}}
-      `(line-number-current-line ((t (:inherit fringe :foreground "black" :weight bold))))))
-     {{/hasdarkbg}}
+      `(line-number-current-line ((t (:inherit fringe :foreground ,fg6 :weight bold))))))
+
   ;; emacs >= 27.1
   (when (>= emacs-major-version 27)
     (custom-theme-set-faces

--- a/app.core/resources/public/templates/textadept-12.txt
+++ b/app.core/resources/public/templates/textadept-12.txt
@@ -45,6 +45,14 @@ colors.selection = {{selection}}
 colors.warning   = {{warning}}
 colors.warning2  = {{warning2}}
 
+-- Normal colors.
+-- Used by some modules, like file-diff or lsp
+colors.red = 0x000099
+colors.orange = 0x0066CC
+colors.yellow = 0x009999
+colors.green = 0x009900
+colors.blue = 0xCC6600
+
 -- Default font.
 if not font then
   font = WIN32 and 'Consolas' or OSX and 'Monaco' or

--- a/app.core/resources/public/templates/textadept-12.txt
+++ b/app.core/resources/public/templates/textadept-12.txt
@@ -1,0 +1,172 @@
+--- {{themename}}.lua
+
+-- Copyright (C) {{year}} , {{themeauthor}}
+
+-- Author: {{themeauthor}}
+-- Created with ThemeCreator, https://github.com/mswift42/themecreator.
+-- Textadept-12 theme template was provided by Pedro A. Aranda Gutiérrez,
+-- https://github.com/paaguti.
+-- Derived from the stock themes provided by Mitchell
+
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+-- GNU General Public License for more details.
+
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+-- This file is not part of TextAdept
+
+local view, colors, styles = view, view.colors, view.styles
+
+colors.fg1       = {{mainfg}}
+colors.fg2       = {{fg2}}
+colors.fg3       = {{fg3}}
+colors.fg4       = {{fg4}}
+colors.bg1       = {{mainbg}}
+colors.bg2       = {{bg2}}
+colors.bg3       = {{bg3}}
+colors.bg4       = {{bg4}}
+colors.builtin   = {{builtin}}
+colors.keyword   = {{keyword}}
+colors.const     = {{constant}}
+colors.comment   = {{comment}}
+colors.func      = {{functionname}}
+colors.str       = {{string}}
+colors.type      = {{type}}
+colors.var       = {{variable}}
+colors.selection = {{selection}}
+colors.warning   = {{warning}}
+colors.warning2  = {{warning2}}
+
+-- Default font.
+if not font then
+  font = WIN32 and 'Consolas' or OSX and 'Monaco' or
+    'Bitstream Vera Sans Mono'
+end
+if not size then size = OSX and 12 or 11 end
+
+-- Find/replace dialog
+ui.find.entry_font = font .. ' ' .. (size - 1)
+
+-- Predefined styles.
+styles[view.STYLE_DEFAULT] = { font = font, size = size, fore = colors.fg1, back = colors.bg1}
+styles[view.STYLE_LINENUMBER] = {fore = colors.fg1, back = colors.bg2}
+styles[view.STYLE_BRACELIGHT] = {fore = colors.func, bold = true}
+styles[view.STYLE_BRACEBAD] = {fore=colors.warning, bold=true}
+-- styles[view.STYLE_CONTROLCHAR] = {}
+styles[view.STYLE_INDENTGUIDE] = {fore = colors.comment}
+styles[view.STYLE_CALLTIP] = {fore = colors.fg1, back = colors.bg2}
+styles[view.STYLE_FOLDDISPLAYTEXT] = {fore = colors.bg2}
+
+-- Tgag styles.
+-- styles[lexer.ANNOTATION] = {fore = colors.magenta}
+styles[lexer.ATTRIBUTE] = {fore = colors.fg3}
+styles[lexer.BOLD] = {bold = true}
+styles[lexer.CLASS] =  {fore = colors.func, bold = true}
+--styles[lexer.CODE] =  {}
+styles[lexer.COMMENT] =  {fore = colors.comment}
+styles[lexer.CONSTANT] =  {fore = colors.const}
+styles[lexer.CONSTANT_BUILTIN] =  {fore = colors.const, bold=true}
+styles[lexer.EMBEDDED] =  {fore = colors.builtin, back = colors.bg2}
+styles[lexer.ERROR] =  {fore = colors.warning, italics = true}
+styles[lexer.FUNCTION] = {fore = colors.func}
+styles[lexer.FUNCTION_BUILTIN] = {fore = colors.func, bold=true}
+-- styles[lexer.FUNCTION_METHOD] = {}
+styles[lexer.HEADING] =  {fore=colors.var}
+styles[lexer.IDENTIFIER] =  {fore=colors.var}
+styles[lexer.ITALIC] =  {italic=true}
+styles[lexer.KEYWORD] =  {fore = colors.keyword}
+styles[lexer.LABEL] =  {fore = colors.warning}
+-- styles[lexer.LINK] =  {}
+-- styles[lexer.LIST] =  {}
+styles[lexer.NUMBER] =  {fore = colors.const}
+styles[lexer.OPERATOR] =  {fore = colors.fg2}
+styles[lexer.PREPROCESSOR] =  {fore = colors.str}
+styles[lexer.REFERENCE] =  {fore = colors.var}
+styles[lexer.REGEX] =  {fore = colors.str}
+styles[lexer.STRING] =  {fore = colors.str}
+styles[lexer.TAG] =  {fore = colors.fg3}
+styles[lexer.TYPE] =  {fore = colors.func}
+-- styles[lexer.UNDERLINE] =  {fore = colors.warning}
+styles[lexer.VARIABLE] =  {fore = colors.warning}
+styles[lexer.VARIABLE_BUILTIN] =  {fore = colors.warning, bold=true}
+-- styles[lexer.WHITESPACE] =  {}
+
+-- CSS.
+-- styles.property = styles[lexer.ATTRIBUTE]
+-- styles.pseudoclass = {}
+-- styles.pseudoelement = {}
+-- Diff.
+styles.addition = {fore = colors.str}
+styles.deletion = {fore = colors.warning}
+styles.change = {fore = colors.warning2}
+-- HTML.
+styles.tag_unknown = styles.tag .. {italics = true}
+styles.attribute_unknown = styles.attribute .. {italics = true}
+-- Latex, TeX, and Texinfo.
+styles.command = styles[lexer.KEYWORD]
+styles.command_section = styles[lexer.HEADING]
+styles.environment = styles[lexer.TYPE]
+styles.environment_math = styles[lexer.NUMBER]
+-- Makefile.
+-- styles.target = {}
+-- Markdown.
+-- styles.hr = {}
+-- XML.
+-- styles.cdata = {}
+-- YAML.
+styles.error_indent = {back = colors.warning}
+
+-- Element colors.
+-- view.element_color[view.ELEMENT_SELECTION_TEXT] = colors.black
+view.element_color[view.ELEMENT_SELECTION_BACK] = colors.selection
+-- view.element_color[view.ELEMENT_SELECTION_ADDITIONAL_TEXT] = colors.black
+-- view.element_color[view.ELEMENT_SELECTION_ADDITIONAL_BACK] = colors.light_grey
+-- view.element_color[view.ELEMENT_SELECTION_SECONDARY_TEXT] = colors.black
+-- view.element_color[view.ELEMENT_SELECTION_SECONDARY_BACK] = colors.light_grey
+-- view.element_color[view.ELEMENT_SELECTION_INACTIVE_TEXT] = colors.black
+-- view.element_color[view.ELEMENT_SELECTION_INACTIVE_BACK] = colors.light_grey
+view.element_color[view.ELEMENT_CARET] = colors.fg2
+-- view.element_color[view.ELEMENT_CARET_ADDITIONAL] =
+-- view.element_color[view.ELEMENT_CARET_LINE_BACK] = colors.light_grey | 0x60000000
+view.caret_line_layer = view.LAYER_UNDER_TEXT
+
+-- Fold Margin.
+view:set_fold_margin_color(true, colors.bg2)
+view:set_fold_margin_hi_color(true, colors.bg2)
+
+-- Markers.
+--view.marker_fore[textadept.bookmarks.MARK_BOOKMARK] = colors.bg1
+view.marker_back[textadept.bookmarks.MARK_BOOKMARK] = colors.str
+--view.marker_fore[textadept.run.MARK_WARNING] = colors.bg1
+view.marker_back[textadept.run.MARK_WARNING] = colors.keyword
+--view.marker_fore[textadept.run.MARK_ERROR] = colors.bg1
+view.marker_back[textadept.run.MARK_ERROR] = colors.warning
+for i = view.MARKNUM_FOLDEREND, view.MARKNUM_FOLDEROPEN do -- fold margin
+  view.marker_fore[i] = colors.bg1
+  view.marker_back[i] = colors.comment
+  view.marker_back_selected[i] = colors.bg3
+end
+
+-- Indicators.
+view.indic_fore[ui.find.INDIC_FIND] = colors.const
+view.indic_alpha[ui.find.INDIC_FIND] = 255
+view.indic_fore[textadept.editing.INDIC_HIGHLIGHT] = colors.fg4
+view.indic_alpha[textadept.editing.INDIC_HIGHLIGHT] = 64
+view.indic_fore[textadept.snippets.INDIC_PLACEHOLDER] = colors.fg1
+
+-- Call tips.
+view.call_tip_fore_hlt = colors.fg3
+
+-- Long Lines.
+view.edge_color = colors.bg3
+
+-- Find & replace pane entries.
+ui.find.entry_font = font .. ' ' .. (size - 1)

--- a/app.core/resources/public/templates/textadept-12.txt
+++ b/app.core/resources/public/templates/textadept-12.txt
@@ -29,6 +29,7 @@ colors.fg1       = {{mainfg}}
 colors.fg2       = {{fg2}}
 colors.fg3       = {{fg3}}
 colors.fg4       = {{fg4}}
+colors.fg6       = {{fg6}}
 colors.bg1       = {{mainbg}}
 colors.bg2       = {{bg2}}
 colors.bg3       = {{bg3}}
@@ -64,7 +65,7 @@ if not size then size = OSX and 12 or 11 end
 ui.find.entry_font = font .. ' ' .. (size - 1)
 -- Predefined styles.
 styles[view.STYLE_DEFAULT] = { font = font, size = size, fore = colors.fg1, back = colors.bg1}
-styles[view.STYLE_LINENUMBER] = {fore = colors.fg1, back = colors.bg2}
+styles[view.STYLE_LINENUMBER] = {fore = colors.fg6, back = colors.bg2}
 styles[view.STYLE_BRACELIGHT] = {fore = colors.func,back=colors.bg2, bold = true}
 styles[view.STYLE_BRACEBAD] = {fore=colors.warning,back=colors.bg3, bold=true}
 -- styles[view.STYLE_CONTROLCHAR] = {}

--- a/app.core/resources/public/templates/textadept-12.txt
+++ b/app.core/resources/public/templates/textadept-12.txt
@@ -62,12 +62,11 @@ if not size then size = OSX and 12 or 11 end
 
 -- Find/replace dialog
 ui.find.entry_font = font .. ' ' .. (size - 1)
-
 -- Predefined styles.
 styles[view.STYLE_DEFAULT] = { font = font, size = size, fore = colors.fg1, back = colors.bg1}
 styles[view.STYLE_LINENUMBER] = {fore = colors.fg1, back = colors.bg2}
-styles[view.STYLE_BRACELIGHT] = {fore = colors.func, bold = true}
-styles[view.STYLE_BRACEBAD] = {fore=colors.warning, bold=true}
+styles[view.STYLE_BRACELIGHT] = {fore = colors.func,back=colors.bg2, bold = true}
+styles[view.STYLE_BRACEBAD] = {fore=colors.warning,back=colors.bg3, bold=true}
 -- styles[view.STYLE_CONTROLCHAR] = {}
 styles[view.STYLE_INDENTGUIDE] = {fore = colors.comment}
 styles[view.STYLE_CALLTIP] = {fore = colors.fg1, back = colors.bg2}
@@ -112,9 +111,9 @@ styles[lexer.VARIABLE_BUILTIN] =  {fore = colors.warning, bold=true}
 -- styles.pseudoclass = {}
 -- styles.pseudoelement = {}
 -- Diff.
-styles.addition = {fore = colors.str}
-styles.deletion = {fore = colors.warning}
-styles.change = {fore = colors.warning2}
+styles.addition = {fore = colors.green}
+styles.deletion = {fore = colors.red}
+styles.change = {fore = colors.blue}
 -- HTML.
 styles.tag_unknown = styles.tag .. {italics = true}
 styles.attribute_unknown = styles.attribute .. {italics = true}
@@ -154,7 +153,7 @@ view:set_fold_margin_hi_color(true, colors.bg2)
 --view.marker_fore[textadept.bookmarks.MARK_BOOKMARK] = colors.bg1
 view.marker_back[textadept.bookmarks.MARK_BOOKMARK] = colors.str
 --view.marker_fore[textadept.run.MARK_WARNING] = colors.bg1
-view.marker_back[textadept.run.MARK_WARNING] = colors.keyword
+view.marker_back[textadept.run.MARK_WARNING] = colors.warning2
 --view.marker_fore[textadept.run.MARK_ERROR] = colors.bg1
 view.marker_back[textadept.run.MARK_ERROR] = colors.warning
 for i = view.MARKNUM_FOLDEREND, view.MARKNUM_FOLDEROPEN do -- fold margin

--- a/app.core/src/app/app.cljs
+++ b/app.core/src/app/app.cljs
@@ -128,8 +128,8 @@
      (str (:themename @app-db) ".tmTheme") @tmthemetemplate]
     [template-download "emacslink" "Emacs"
      (str (:themename @app-db) "-theme.el") @emacstemplate ]
-    [template-download-textadept "talink"   "Textadept"    "tatemplate"]
-    [template-download-textadept "ta12link" "Textadept 12" "ta12template"]
+    [template-download-textadept "talink"   "Textadept"    @tatemplate]
+    [template-download-textadept "ta12link" "Textadept 12" @ta12template]
     [template-download "vimlink" "Vim"
      (str (:themename @app-db) ".vim") @vimtemplate]
     [template-download "gnometerminallink" "Gnome Terminal"

--- a/app.core/src/app/app.cljs
+++ b/app.core/src/app/app.cljs
@@ -25,6 +25,7 @@
 (def atomtemplate (atom ""))
 (def emacstemplate (atom ""))
 (def tatemplate (atom ""))
+(def ta12template (atom ""))
 (def vimtemplate (atom ""))
 (def gnometerminaltemplate (atom ""))
 (def vscodetemplate (atom ""))
@@ -104,12 +105,12 @@
     "IntelliJ"]])
 
 (defn template-download-textadept
-  []
+  [id title template]
   [:li
-   [:a {:href "#" :id "textadeptlink" :on-click
-        #(create-blob (generate-template-textadept @tatemplate) "textadeptlink"
+   [:a {:href "#" :id id :on-click
+        #(create-blob (generate-template-textadept template) id
                       (str (:themename @app-db) ".lua"))}
-    "Textadept"]])
+    title]])
 
 
 (defn template-select-component
@@ -127,7 +128,8 @@
      (str (:themename @app-db) ".tmTheme") @tmthemetemplate]
     [template-download "emacslink" "Emacs"
      (str (:themename @app-db) "-theme.el") @emacstemplate ]
-    [template-download-textadept]
+    [template-download-textadept "talink"   "Textadept"    "tatemplate"]
+    [template-download-textadept "ta12link" "Textadept 12" "ta12template"]
     [template-download "vimlink" "Vim"
      (str (:themename @app-db) ".vim") @vimtemplate]
     [template-download "gnometerminallink" "Gnome Terminal"
@@ -197,6 +199,7 @@
   (GET "templates/tmtheme.txt" tmthemetemplate)
   (GET "templates/emacs.txt" emacstemplate)
   (GET "templates/textadept.txt" tatemplate)
+  (GET "templates/textadept-12.txt" ta12template)
   (GET "templates/vim.txt" vimtemplate)
   (GET "templates/gnome-terminal.txt" gnometerminaltemplate)
   (GET "templates/vscode/package.json" vscodepackagejsontemplate)

--- a/app.core/src/app/colors.cljs
+++ b/app.core/src/app/colors.cljs
@@ -41,7 +41,7 @@
   [rgbcolor]
   (let [[r g b]
         (mapv #(* % 100)
-              (mapv 
+              (mapv
                #(if (> % 0.04045)
                   (js/Math.pow (/ (+ % 0.055) 1.055) 2.4)
                   (/ % 12.92)) rgbcolor))]
@@ -58,7 +58,7 @@
                          (+ (* % 7.787) (/ 16 116)))
                       (mapv / xyzcolor xyzreferencewhited65))]
     [(- (* 116 y) 16)
-     (* 500 (- x y)) 
+     (* 500 (- x y))
      (* 200 (- y z))]))
 
 (defn radToDegrees
@@ -124,7 +124,7 @@
 
 (defn darken
   "darken darkens a rgb color by a given factor.
-   if no factor is provided, the color will be darkened 
+   if no factor is provided, the color will be darkened
    with the factor of 0.2."
   ([colorstring] (darken colorstring 0.2))
   ([colorstring factor]
@@ -210,7 +210,7 @@
 (defn color-list
   "color-list takes a lightness and saturation value from the Cie-lch Color Space
    and returns a vector of size length of db/randomcolors. Hue values for each color
-   are of equidistant value. Every lch color is converted to rgb, then clamped if 
+   are of equidistant value. Every lch color is converted to rgb, then clamped if
    necessary and finally converted to Hex format."
   [lightness saturation]
   (let [hr (hue-range (count db/randomcolors) (random-hue))]
@@ -226,7 +226,7 @@
     (color-list 44.921 25.738)))
 
 (defn warm-palette
-  "warm-palette returns a vector of 7 random warm colors." 
+  "warm-palette returns a vector of 7 random warm colors."
   []
   (if (dark-bg? (:mainbg @db/app-db))
     (color-list  60.39 33.84)
@@ -269,7 +269,7 @@
 
 
 (defn derive-colors-from-theme
-  "return a theme map with additional lighter/darker 
+  "return a theme map with additional lighter/darker
    variants of the background and foreground colors."
   [theme]
   (let [dbg (dark-bg? (:mainbg theme))]
@@ -280,6 +280,7 @@
              :fg3 (darken (:mainfg theme) 0.16)
              :fg4 (darken (:mainfg theme) 0.24)
              :fg5 (lighten (:mainfg theme) 0.12)
+             :fg6 (lighten (:mainfg theme) 0.24)
              :bg2 (lighten (:mainbg theme) 0.08)
              :bg3 (lighten (:mainbg theme) 0.16)
              :bg4 (lighten (:mainbg theme) 0.24)
@@ -290,11 +291,8 @@
              :fg3 (lighten (:mainfg theme) 0.16)
              :fg4 (lighten (:mainfg theme) 0.24)
              :fg5 (darken  (:mainfg theme) 0.08)
+             :fg6 (darken  (:mainfg theme) 0.24)
              :bg2 (darken (:mainbg theme) 0.08)
              :bg3 (darken (:mainbg theme) 0.16)
              :bg4 (darken (:mainbg theme) 0.24)
              :year (current-year)))))
-
-
-
-


### PR DESCRIPTION
Textadept 12 is in the making and themes (and other things) are changing a lot. This justifies adding a new template instead of replacing the current version.
This is WIP. I'd like to add the "normal" colours in the luminosity logic. TA12 defines them for things like file diffs.
