### PR TITLE
Correcting Emacs version to 24.1 due to org blocks used, and revising…

### DIFF
--- a/app.core/resources/public/templates/emacs.txt
+++ b/app.core/resources/public/templates/emacs.txt
@@ -4,9 +4,8 @@
 
 ;; Author: {{themeauthor}}
 ;; Version: 0.1
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24.1"))
 ;; Created with ThemeCreator, https://github.com/mswift42/themecreator.
-
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -24,6 +23,7 @@
 ;; This file is not part of Emacs.
 
 ;;; Commentary:
+;;; {{themename}} theme created by {{themeauthor}} in {{year}}
 
 ;;; Code:
 
@@ -243,8 +243,7 @@
    `(jde-java-font-lock-modifier-face ((t (:foreground ,fg2))))
    `(jde-jave-font-lock-protected-face ((t (:foreground ,keyword))))
    `(jde-java-font-lock-number-face ((t (:foreground ,var))))
-   `(yas-field-highlight-face ((t (:background ,selection))))
-   )
+   `(yas-field-highlight-face ((t (:background ,selection)))))
    ;; Legacy
    (if (< emacs-major-version 22)
        (custom-theme-set-faces
@@ -291,9 +290,7 @@
   (when (boundp 'font-lock-regexp-face)
     (custom-theme-set-faces
     '{{themename}}
-    `(font-lock-regexp-face ((,class (:inherit font-lock-string-face :underline t))))
-    ))
-)
+    `(font-lock-regexp-face ((,class (:inherit font-lock-string-face :underline t)))))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
… parens for MELPA requirements

Hello,

I am making these revisions to be more compliant with MELPA submission requirements as I have had to make several slight revisions in order to allow the default linter for MELPA submissions to be okay with themes created using the 'themecreator' website export functionality.

These revisions including requiring Emacs 24.1 because of the Org components mentioned, as well as having parentheses on joined lines to prevent a hanging parentheses since the linter does not like that.

Also, I added a 'Commentary' section which has to be filled out as well for MELPA submission.

Based upon these changes, this should allow themes created with 'themecreator' to easily be added to MELPA.